### PR TITLE
Fix cashflow missing retail debt expense

### DIFF
--- a/src/app/features/professions/create-new-profession/create-new-profession.component.ts
+++ b/src/app/features/professions/create-new-profession/create-new-profession.component.ts
@@ -101,12 +101,12 @@ export class CreateNewProfessionComponent {
   }
 
   private _upsertProfessionRequest(): Observable<number> {
-    const profession: TypedFormValue<FormGroup<ProfessionForm>> = this.professionForm.value;
+    const professionValue: TypedFormValue<FormGroup<ProfessionForm>> = this.professionForm.value;
 
     if (this.profession()) {
-      return this._professionService.update({ ...profession, id: this.profession().id, createdAt: this.profession().createdAt });
+      return this._professionService.update({ ...professionValue, id: this.profession().id, createdAt: this.profession().createdAt });
     } else {
-      return this._professionService.add(profession);
+      return this._professionService.add(professionValue);
     }
   }
 

--- a/src/app/shared/services/db/session.service.ts
+++ b/src/app/shared/services/db/session.service.ts
@@ -11,7 +11,7 @@ import { Profession } from '../../models/database/cashflow.db';
 export class SessionService {
     constructor(
         private indexedDbService: IndexedDbService
-    ) {}
+    ) { }
 
     public add(profession: Profession): Observable<number> {
         const session = this._constructNewSession(profession);
@@ -21,12 +21,13 @@ export class SessionService {
 
     private _constructNewSession(profession: Profession): Partial<Session> {
         const expenses: ExpenseItem[] = [
-            {name: $localize`:@@taxes:Taxes`, cashflow: profession.expenses.taxes},
-            {name: $localize`:@@otherPayments:Other payments`, cashflow: profession.expenses.other},
-            {name: $localize`:@@homeMortgage:Home mortgage`, cashflow: profession.expenses.homeMortgage, value: profession.liabilities.homeMortgage, isLiability: true},
-            {name: $localize`:@@schoolLoans:School loans`, cashflow: profession.expenses.schoolLoan, value: profession.liabilities.schoolLoan, isLiability: true},
-            {name: $localize`:@@carLoans:Car loans`, cashflow: profession.expenses.carLoan, value: profession.liabilities.carLoan, isLiability: true},
-            {name: $localize`:@@creditCards:Credit cards`, cashflow: profession.expenses.creditCard, value: profession.liabilities.creditCard, isLiability: true},
+            { name: $localize`:@@carLoans:Car loans`, cashflow: profession.expenses.carLoan, value: profession.liabilities.carLoan, isLiability: true },
+            { name: $localize`:@@creditCards:Credit cards`, cashflow: profession.expenses.creditCard, value: profession.liabilities.creditCard, isLiability: true },
+            { name: $localize`:@@homeMortgage:Home mortgage`, cashflow: profession.expenses.homeMortgage, value: profession.liabilities.homeMortgage, isLiability: true },
+            { name: $localize`:@@schoolLoans:School loans`, cashflow: profession.expenses.schoolLoan, value: profession.liabilities.schoolLoan, isLiability: true },
+            { name: $localize`:@@otherPayments:Other payments`, cashflow: profession.expenses.other },
+            { name: $localize`:@@taxes:Taxes`, cashflow: profession.expenses.taxes },
+            { name: $localize`:@@retailDebt:Retail debt`, cashflow: profession.expenses.retail, value: profession.liabilities.retail, isLiability: true }
         ];
 
         return {
@@ -39,12 +40,12 @@ export class SessionService {
 
     public get(id: number): Observable<Session> {
         return from(this.indexedDbService.getData("sessions", id))
-          .pipe(map((session: Session) => new Session(session)));
+            .pipe(map((session: Session) => new Session(session)));
     }
 
     public query(): Observable<Session[]> {
         return from(this.indexedDbService.getAllData("sessions"))
-          .pipe(map((sessions: Session[]) => sessions.map(session => new Session(session))));
+            .pipe(map((sessions: Session[]) => sessions.map(session => new Session(session))));
     }
 
     public update(session: Session): Observable<number> {


### PR DESCRIPTION
All data is saved properly when create new profession. However, when creating new session, expense section is missing retail debt.
So cashflow is not the same after start new session

Work done:
Add missing retail debt expense when create new session

Create profession
![image](https://github.com/user-attachments/assets/212e25a8-1793-48a5-a334-b74ceb8f2a54)

Start session
![image](https://github.com/user-attachments/assets/cd7038ff-641f-4a02-8aa8-078f4db01f70)
