### PR TITLE
Fix buy asset with down payment 0 but counted as cost

### DIFF
--- a/src/app/features/actions/assets/buy-asset/buy-asset.component.ts
+++ b/src/app/features/actions/assets/buy-asset/buy-asset.component.ts
@@ -69,8 +69,8 @@ export class BuyAssetComponent {
     const newAsset: AssetItem = {
       name: this.assetType === DEAL_TYPE.HOUSING ? HOUSE_TYPE_LABEL[formValue.assetName] : formValue.assetName,
       value: formValue.cost,
-      downPayment: formValue.downPayment,
-      cashflow: formValue.cashFlow,
+      downPayment: formValue.downPayment || 0,
+      cashflow: formValue.cashFlow || 0,
       isLiability: true,
       assetType: this.assetType
     }

--- a/src/app/shared/services/stores/session-store.service.ts
+++ b/src/app/shared/services/stores/session-store.service.ts
@@ -114,7 +114,7 @@ export class SessionStoreService extends ComponentStore<SessionState> {
   }
 
   public addAsset(asset: AssetItem): void {
-    const payment = asset.downPayment || asset.value;
+    const payment = asset.downPayment ?? asset.value;
 
     this.patchState((state: SessionState) => {
       const newSession = {


### PR DESCRIPTION
Using nullish coalescing operator instead of OR operator to have same effect as totalPayment in buy-asset component

Also set default value of down payment and cashflow default value to 0 to fix null cashflow asset
![image](https://github.com/user-attachments/assets/ae28acaa-d77e-4b60-8116-5be6fe174051)
